### PR TITLE
Include info on program location after deb install

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,14 @@ If your system supports deb files, you can simply grab an automatic build from h
 
 `sudo dpkg -i k81x-fkeys_<version>_amd64.deb`
 
+You can then run the program at `/opt/k81x/k81x-fkeys`.
+
 For Arch Linux you can use the AUR package:
 ```
 gpg --recv-keys --keyserver hkp://pool.sks-keyservers.net 7FBFBFD17A45CAE7
 pacaur -S k81x-fkeys
 ```
+
 
 ## Installing from source code
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ gpg --recv-keys --keyserver hkp://pool.sks-keyservers.net 7FBFBFD17A45CAE7
 pacaur -S k81x-fkeys
 ```
 
-
 ## Installing from source code
 
 ### Building


### PR DESCRIPTION
Alas I am not too familiar with the deb system and it took me a while to find where the program was installed as the program wasn't on the path and I didn't know the commands to look into a deb. Eventually I found it out but I thought it might be helpful for future users to have the info included in the README.